### PR TITLE
add benchmark for `pull-notify`

### DIFF
--- a/benchmark/emit-arrays.js
+++ b/benchmark/emit-arrays.js
@@ -113,6 +113,13 @@ test('emit multiple arrays', function (t) {
       subjects.signalLite.broadcast(['bar', 'baz', 'boom']);
     });
 
+    s.bench('pull-notify', function () {
+      called = called2 = 0;
+      subjects.pullNotify(['bar']);
+      subjects.pullNotify(['bar', 'baz']);
+      subjects.pullNotify(['bar', 'baz', 'boom']);
+    });
+
     function handle(a) {
       if (arguments.length === 1 && a === undefined) {
         return;

--- a/benchmark/emit-one-objects-two-listeners.js
+++ b/benchmark/emit-one-objects-two-listeners.js
@@ -57,6 +57,13 @@ test('emit one object', function (t) {
       subjects.pushStream.push({bar: 'bar', baz: 'baz', boom: 'boom'});
     });
 
+    s.bench('pull-notify', function () {
+      called = called2 = 0;
+      subjects.pullNotify({bar: 'bar'});
+      subjects.pullNotify({bar: 'bar', baz: 'baz'});
+      subjects.pullNotify({bar: 'bar', baz: 'baz', boom: 'boom'});
+    });
+
     s.bench('dripEmitter', function () {
       called = called2 = 0;
       subjects.dripEmitter.emit('foo', {bar: 'bar'});

--- a/benchmark/emit-one-objects-two-listeners.js
+++ b/benchmark/emit-one-objects-two-listeners.js
@@ -57,13 +57,6 @@ test('emit one object', function (t) {
       subjects.pushStream.push({bar: 'bar', baz: 'baz', boom: 'boom'});
     });
 
-    s.bench('pull-notify', function () {
-      called = called2 = 0;
-      subjects.pullNotify({bar: 'bar'});
-      subjects.pullNotify({bar: 'bar', baz: 'baz'});
-      subjects.pullNotify({bar: 'bar', baz: 'baz', boom: 'boom'});
-    });
-
     s.bench('dripEmitter', function () {
       called = called2 = 0;
       subjects.dripEmitter.emit('foo', {bar: 'bar'});
@@ -132,6 +125,13 @@ test('emit one object', function (t) {
       subjects.eventDispatcher.dispatchEvent({type: 'foo', bar: 'bar'});
       subjects.eventDispatcher.dispatchEvent({type: 'foo', bar: 'bar', baz: 'baz'});
       subjects.eventDispatcher.dispatchEvent({type: 'foo', bar: 'bar', baz: 'baz', boom: 'boom'});
+    });
+
+    s.bench('pull-notify', function () {
+      called = called2 = 0;
+      subjects.pullNotify({bar: 'bar'});
+      subjects.pullNotify({bar: 'bar', baz: 'baz'});
+      subjects.pullNotify({bar: 'bar', baz: 'baz', boom: 'boom'});
     });
 
     function handle(a) {

--- a/benchmark/emit-one-value-bound-function.js
+++ b/benchmark/emit-one-value-bound-function.js
@@ -1,5 +1,6 @@
 var suite = require('chuhai');
 var test = require('blue-tape');
+var pull = require('pull-stream');
 var setup = require('../subjects');
 
 test('emit with bound function', function (t) {
@@ -47,6 +48,8 @@ test('emit with bound function', function (t) {
     subjects.subject.subscribe(handle2);
     subjects.rProperty.on(handle.bind(ctx));
     subjects.rProperty.on(handle2);
+    pull(subjects.pullNotify.listen(), pull.drain(handle.bind(ctx)));
+    pull(subjects.pullNotify.listen(), pull.drain(handle2));
 
     var bHandel = handle.bind(ctx);
 
@@ -114,6 +117,11 @@ test('emit with bound function', function (t) {
     s.bench('signal-lite', function () {
       called = called2 = 0;
       subjects.signalLite.broadcast('bar');
+    });
+
+    s.bench('pull-notify', function () {
+      called = called2 = 0;
+      subjects.pullNotify('bar');
     });
 
     function handle() {

--- a/benchmark/emit-one-value-one-listener.js
+++ b/benchmark/emit-one-value-one-listener.js
@@ -52,11 +52,6 @@ test('emit one value - one listener', function (t) {
       subjects.pushStream.push('bar');
     });
 
-    s.bench('pull-notify', function () {
-      called = 0;
-      subjects.pullNotify('bar');
-    });
-
     s.bench('dripEmitterEnhanced', function () {
       called = 0;
       subjects.dripEmitterEnhanced.emit('foo', 'bar');
@@ -120,6 +115,11 @@ test('emit one value - one listener', function (t) {
     s.bench('minivents', function () {
       called = 0;
       subjects.miniVent.emit('foo', 'bar');
+    });
+
+    s.bench('pull-notify', function () {
+      called = 0;
+      subjects.pullNotify('bar');
     });
 
     function handle(a) {

--- a/benchmark/emit-one-value-one-listener.js
+++ b/benchmark/emit-one-value-one-listener.js
@@ -52,6 +52,11 @@ test('emit one value - one listener', function (t) {
       subjects.pushStream.push('bar');
     });
 
+    s.bench('pull-notify', function () {
+      called = 0;
+      subjects.pullNotify('bar');
+    });
+
     s.bench('dripEmitterEnhanced', function () {
       called = 0;
       subjects.dripEmitterEnhanced.emit('foo', 'bar');

--- a/benchmark/emit-one-value-two-listeners.js
+++ b/benchmark/emit-one-value-two-listeners.js
@@ -55,6 +55,11 @@ test('emit one value - two listeners', function (t) {
       subjects.pushStream.push('bar');
     });
 
+    s.bench('pull-notify', function () {
+      called = called2 = 0;
+      subjects.pullNotify('bar');
+    });
+
     s.bench('dripEmitterEnhanced', function () {
       called = called2 = 0;
       subjects.dripEmitterEnhanced.emit('foo', 'bar');

--- a/benchmark/emit-one-value-two-listeners.js
+++ b/benchmark/emit-one-value-two-listeners.js
@@ -55,11 +55,6 @@ test('emit one value - two listeners', function (t) {
       subjects.pushStream.push('bar');
     });
 
-    s.bench('pull-notify', function () {
-      called = called2 = 0;
-      subjects.pullNotify('bar');
-    });
-
     s.bench('dripEmitterEnhanced', function () {
       called = called2 = 0;
       subjects.dripEmitterEnhanced.emit('foo', 'bar');
@@ -123,6 +118,11 @@ test('emit one value - two listeners', function (t) {
     s.bench('minivents', function () {
       called = called2 = 0;
       subjects.miniVent.emit('foo', 'bar');
+    });
+
+    s.bench('pull-notify', function () {
+      called = called2 = 0;
+      subjects.pullNotify('bar');
     });
 
     function handle(a) {

--- a/benchmark/emit-one-value-with-context.js
+++ b/benchmark/emit-one-value-with-context.js
@@ -1,5 +1,6 @@
 var suite = require('chuhai');
 var test = require('blue-tape');
+var pull = require('pull-stream');
 var setup = require('../subjects');
 
 test('emit with context', function (t) {
@@ -47,6 +48,8 @@ test('emit with context', function (t) {
     subjects.subject.subscribe(handle2);
     subjects.rProperty.on(handle.bind(ctx));
     subjects.rProperty.on(handle2);
+    pull(subjects.pullNotify.listen(), pull.drain(handle.bind(ctx)));
+    pull(subjects.pullNotify.listen(), pull.drain(handle2));
 
     var bHandel = handle.bind(ctx);
 
@@ -114,6 +117,11 @@ test('emit with context', function (t) {
     s.bench('signal-lite', function () {
       called = called2 = 0;
       subjects.signalLite.broadcast('bar');
+    });
+
+    s.bench('pull-notify', function () {
+      called = called2 = 0;
+      subjects.pullNotify('bar');
     });
 
     function handle() {

--- a/benchmark/init.js
+++ b/benchmark/init.js
@@ -58,5 +58,9 @@ test('init', function (t) {
     s.bench('EventDispatcher', function () {
       dummy = new constructors.EventDispatcher();
     });
+
+    s.bench('pull-notify', function () {
+      dummy = new constructors.pull.notify();
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "observable": "^2.1.4",
     "p-s": "^1.0.1",
     "platform": "^1.3.1",
+    "pull-notify": "^0.1.0",
+    "pull-stream": "^3.4.0",
     "push-stream": "^2.0.3",
     "reactive-property": "^0.9.0",
     "rimraf": "^2.5.2",

--- a/subjects/index.js
+++ b/subjects/index.js
@@ -1,4 +1,3 @@
-
 var EventEmitter1 = require('events').EventEmitter;
 var EventEmitter2 = require('eventemitter2');
 var EventEmitter3 = require('eventemitter3');
@@ -18,6 +17,8 @@ var DripEmitter = require('drip/lib/drip').EventEmitter;
 var DripEmitterEnhanced = require('drip/lib/drip').EnhancedEmitter;
 var barracks = require('barracks');
 var push = require('push-stream');
+var pull = require('pull-stream');
+pull.notify = require('pull-notify');
 var EventDispatcher = require('./eventdispatcher');
 
 if (typeof window === 'undefined') {
@@ -44,7 +45,8 @@ module.exports.constructors = {
   DripEmitter: DripEmitter,
   DripEmitterEnhanced: DripEmitterEnhanced,
   barracks: barracks,
-  push: push
+  push: push,
+  pull: pull
 };
 
 module.exports.createInstances = createInstances;
@@ -74,6 +76,7 @@ function createInstances() {
   var dripEmitterEnhanced = new DripEmitterEnhanced();
   var barracksDispatcher = barracks();
   var pushStream = push.stream();
+  var pullNotify = pull.notify();
 
   return {
     ee1: ee1,
@@ -95,7 +98,8 @@ function createInstances() {
     dripEmitter: dripEmitter,
     dripEmitterEnhanced: dripEmitterEnhanced,
     barracksDispatcher: barracksDispatcher,
-    pushStream: pushStream
+    pushStream: pushStream,
+    pullNotify: pullNotify
   };
 }
 
@@ -121,6 +125,7 @@ function addHandles(subjects, handels) {
     subjects.dripEmitterEnhanced.on('foo', h);
     subjects.barracksDispatcher.on('foo', h);
     subjects.pushStream(h);
+    pull(subjects.pullNotify.listen(), pull.drain(h));
   });
 
   return subjects;


### PR DESCRIPTION
hey @Hypercubed,

here's a preliminary benchmark for [`pull-notify`](https://github.com/pull-stream/pull-notify), a "observer pattern" interface to [pull streams](https://pull-stream.github.io).

i ported any benchmarks involving `push-stream`, but am missing many that are included in [your latest `push-stream` benchmark](https://gist.github.com/Hypercubed/d51a566a307b428d98eaf3aa8d2a59a3). EDIT: added more.
